### PR TITLE
Properly Download Different Versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,7 @@ docker run \
 |---|---|---|---|
 |`JAVA_TOOL_OPTIONS` | JVM Settings, like heap size | `-Xmx1024M -Xms1024M` | Environment Variable|
 |`broadcast-rcon-to-ops` | Announce RCON commands to Server Ops | `false` ??? TODO | `server.properties`|
+
+## A Note On Versions
+
+This image used to download the server `.jar` by a special URL but with 1.13, Minecraft changed the pattern of releasing their files. This image has been updated to use the new method, and should continue to work for older versions. More testing in this area is likely needed.

--- a/scripts/healthcheck.py
+++ b/scripts/healthcheck.py
@@ -5,15 +5,17 @@ import socket
 
 import server_properties
 
+
 def minecraft_port_is_open():
     port_number = server_properties.rcon_port
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     return sock.connect_ex(('localhost', port_number)) == 0
 
+
 # If we're calling on this script directly, exit with
 # the return code signifying the status.
 if __name__ == "__main__":
     if minecraft_port_is_open():
-        sys.exit(0) # Pass Healthcheck
+        sys.exit(0)  # Pass Healthcheck
     else:
-        sys.exit(1) # Fail Healthcheck
+        sys.exit(1)  # Fail Healthcheck

--- a/scripts/minecraft_rcon.py
+++ b/scripts/minecraft_rcon.py
@@ -5,8 +5,10 @@ import struct
 
 import server_properties
 
+
 def stop():
     send("stop")
+
 
 # NOTE: This has only been tested with "STOP" command. Your mileage may vary if
 # you try to use this code outside this context.

--- a/scripts/wrapper.py
+++ b/scripts/wrapper.py
@@ -12,6 +12,15 @@ import minecraft_rcon
 MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json"
 
 
+def get_json_from_url(url):
+    if not url.startswith("https://"):
+        raise RuntimeError("Expected URL to start with https://. It is '{}'.".format(url))
+    request = urllib.request.Request(url)
+    with urllib.request.urlopen(request) as response:
+        data = json.loads(response.read().decode())
+    return data
+
+
 # Minecraft now breaks their downloads up into two JSON API calls (instead of
 # predictable URLs). The following function takes a version and a download_type
 # (one of the strings 'client' or 'server'), and returns a URL that can be used
@@ -20,11 +29,7 @@ def get_minecraft_download_url(version, download_type):
     if download_type not in ['client', 'server']:
         raise RuntimeError("Invalid download_type. Expected client or server.")
 
-    if not MANIFEST_URL.startswith("https://");
-        raise RuntimeError("Expected MANIFEST_URL to be https://")
-    request = urllib.request.Request(MANIFEST_URL)
-    with urllib.request.urlopen(request) as response:
-        data = json.loads(response.read().decode())
+    data = get_json_from_url(MANIFEST_URL)
     print("The latest Minecraft is {} (release) and {} (snapshot). You are requesting to download {}.".format(data['latest']['release'], data['latest']['snapshot'], version))
 
     desired_versions = list(filter(lambda v: v['id'] == version, data['versions']))
@@ -35,12 +40,7 @@ def get_minecraft_download_url(version, download_type):
 
     version_manifest_url = desired_versions[0]['url']
     print("Found Version Metadata URL {} for version {}.".format(version_manifest_url, version))
-
-    if not version_manifest_url.startswith("https://");
-        raise RuntimeError("Expected version_manifest_url to be https://")
-    request = urllib.request.Request(version_manifest_url)
-    with urllib.request.urlopen(request) as response:
-        data = json.loads(response.read().decode())
+    data = get_json_from_url(version_manifest_url)
 
     download_url = data['downloads'][download_type]['url']
     print("Found final download URL for version {}. It is: {}".format(version, download_url))

--- a/scripts/wrapper.py
+++ b/scripts/wrapper.py
@@ -20,6 +20,8 @@ def get_minecraft_download_url(version, download_type):
     if download_type not in ['client', 'server']:
         raise RuntimeError("Invalid download_type. Expected client or server.")
 
+    if not MANIFEST_URL.startswith("https://");
+        raise RuntimeError("Expected MANIFEST_URL to be https://")
     request = urllib.request.Request(MANIFEST_URL)
     with urllib.request.urlopen(request) as response:
         data = json.loads(response.read().decode())
@@ -34,6 +36,8 @@ def get_minecraft_download_url(version, download_type):
     version_manifest_url = desired_versions[0]['url']
     print("Found Version Metadata URL {} for version {}.".format(version_manifest_url, version))
 
+    if not version_manifest_url.startswith("https://");
+        raise RuntimeError("Expected version_manifest_url to be https://")
     request = urllib.request.Request(version_manifest_url)
     with urllib.request.urlopen(request) as response:
         data = json.loads(response.read().decode())

--- a/scripts/wrapper.py
+++ b/scripts/wrapper.py
@@ -20,8 +20,9 @@ def get_minecraft_download_url(version, download_type):
     if download_type not in ['client', 'server']:
         raise RuntimeError("Invalid download_type. Expected client or server.")
 
-    with urllib.request.urlopen(MANIFEST_URL) as url:
-        data = json.loads(url.read().decode())
+    request = urllib.request.Request(MANIFEST_URL)
+    with urllib.request.urlopen(request) as response:
+        data = json.loads(response.read().decode())
     print("The latest Minecraft is {} (release) and {} (snapshot). You are requesting to download {}.".format(data['latest']['release'], data['latest']['snapshot'], version))
 
     desired_versions = list(filter(lambda v: v['id'] == version, data['versions']))
@@ -33,8 +34,9 @@ def get_minecraft_download_url(version, download_type):
     version_manifest_url = desired_versions[0]['url']
     print("Found Version Metadata URL {} for version {}.".format(version_manifest_url, version))
 
-    with urllib.request.urlopen(version_manifest_url) as url:
-        data = json.loads(url.read().decode())
+    request = urllib.request.Request(version_manifest_url)
+    with urllib.request.urlopen(request) as response:
+        data = json.loads(response.read().decode())
 
     download_url = data['downloads'][download_type]['url']
     print("Found final download URL for version {}. It is: {}".format(version, download_url))

--- a/scripts/wrapper.py
+++ b/scripts/wrapper.py
@@ -17,7 +17,9 @@ MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json"
 # (one of the strings 'client' or 'server'), and returns a URL that can be used
 # to download the resource.
 def get_minecraft_download_url(version, download_type):
-    assert download_type in ['client', 'server'], "Invalid download_type. Expected client or server."
+    if download_type not in ['client', 'server']:
+        raise RuntimeError("Invalid download_type. Expected client or server.")
+
     with urllib.request.urlopen(MANIFEST_URL) as url:
         data = json.loads(url.read().decode())
     print("The latest Minecraft is {} (release) and {} (snapshot). You are requesting to download {}.".format(data['latest']['release'], data['latest']['snapshot'], version))


### PR DESCRIPTION
_(From Issue #1)_

> Mojang (Microsoft) now releases a manifest instead of a predictable URL. Unfortunately, this means that the current automation breaks during the upgrade to `1.13`. 
> 
> The manifest URL: [`https://launchermeta.mojang.com/mc/game/version_manifest.json`](https://launchermeta.mojang.com/mc/game/version_manifest.json)
> 
> A temporary workaround for 1.13 has been implemented via #2, but the longterm plan is to parse the manifest URL to determine the correct `.jar` to download.